### PR TITLE
Add constituent endpoint and interface

### DIFF
--- a/api/src/data/typeDefs.ts
+++ b/api/src/data/typeDefs.ts
@@ -34,7 +34,7 @@ export type Constituent = {
   email: string;
   phone: string;
   id?: number;
-  date_joined: string;
+  date_joined?: string;
   party: Party;
   state: string;
   city: string;

--- a/api/src/data/typeDefs.ts
+++ b/api/src/data/typeDefs.ts
@@ -33,7 +33,7 @@ export type Constituent = {
   name: string;
   email: string;
   phone: string;
-  id: number;
+  id?: number;
   date_joined: string;
   party: Party;
   state: string;

--- a/api/src/express.ts
+++ b/api/src/express.ts
@@ -24,7 +24,7 @@ app.get('/constituents', (req, res) => {
 });
 
 app.post('/addConstituent', (req, res) => {
-  const constituent = req?.body?.constituent;
+  const constituent = req?.body;
   const constituents = createConstituent(constituent);
   return res.send(constituents);
 });

--- a/api/src/express.ts
+++ b/api/src/express.ts
@@ -1,23 +1,32 @@
 import express from 'express';
 import cors from 'cors';
+import bodyParser from 'body-parser';
 import { getRepresentative } from "./services/representative";
-import { getAllConstituents } from "./services/constituents";
+import { getAllConstituents, createConstituent } from "./services/constituents";
 const app = express();
 const port = 4000;
 
 app.use(cors({
   origin:"*",
-  methods:['GET']
-}))  // Enable CORS for all routes
+  methods:['GET', 'POST']
+}));
+
+app.use(bodyParser.json());
 
 app.get('/representative', (req, res) => {
   const representative = getRepresentative(req?.query?.id);
-  return res.send(representative)
+  return res.send(representative);
 });
 
 app.get('/constituents', (req, res) => {
-  const constituents = getAllConstituents(req?.query?.id);
-  return res.send(constituents)
+  const constituents = getAllConstituents(req?.query?.representativeId);
+  return res.send(constituents);
+});
+
+app.post('/addConstituent', (req, res) => {
+  const constituent = req?.body?.constituent;
+  const constituents = createConstituent(constituent);
+  return res.send(constituents);
 });
 
 app.listen(port, () => {

--- a/api/src/services/constituents.ts
+++ b/api/src/services/constituents.ts
@@ -1,3 +1,4 @@
+import e from "cors";
 import { constituents } from "../data/constituent";
 import { Constituent } from "../data/typeDefs";
 
@@ -30,7 +31,10 @@ export const createConstituent = (constituent: Constituent) => {
 
     if(existingConstituent) {
       console.log('Constituent already exists');
-      return existingConstituent;
+      return {
+        ...existingConstituent,
+        error: 'Constituent already exists',
+      };
     }
 
     // if the constituent doesn't exist, add it

--- a/api/src/services/constituents.ts
+++ b/api/src/services/constituents.ts
@@ -4,12 +4,54 @@ import { Constituent } from "../data/typeDefs";
 export const getAllConstituents = (representativeId: string) => {
   try {
     if (representativeId) {
+      console.log('Getting constituents for representative ID:', representativeId);
       const repConstituents = constituents.filter((constituent: Constituent ) => constituent.representative_id === parseInt(representativeId));
-      return repConstituents
+      return repConstituents;
     }
     throw new Error('No representative ID passed in');
   } catch (error) {
     console.error(error);
     return [];
+  }
+};
+
+export const createConstituent = (constituent: Constituent) => {
+  try {
+    // check if the constituent already exists
+    const existingConstituent = constituents.find((c: Constituent) => {
+      return c.name === constituent.name 
+        && c.email === constituent.email 
+        && c.phone === constituent.phone
+        && c.state === constituent.state
+        && c.city === constituent.city
+        && c.party === constituent.party
+        && c.representative_id === constituent.representative_id;
+    });
+
+    if(existingConstituent) {
+      console.log('Constituent already exists');
+      return existingConstituent;
+    }
+
+    // if the constituent doesn't exist, add it
+    const date = new Date();
+    const formattedDate = new Intl.DateTimeFormat('en-CA', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit'
+    }).format(date);
+
+    const newConstituent = {
+      ...constituent,
+      id: constituents.length + 1,
+      date_joined: formattedDate,
+    };
+
+    constituents.push(newConstituent);
+    console.log('Constituent added', newConstituent);
+    return newConstituent;
+  } catch (error) {
+    console.error(error);
+    return null;
   }
 }

--- a/web/pages/_document.js
+++ b/web/pages/_document.js
@@ -1,4 +1,8 @@
 import { Html, Head, Main, NextScript } from 'next/document'
+
+// preloading styles results in a well documented console warning
+// shouldn't exist in production, and does not cause any issues
+// https://github.com/vercel/next.js/issues/51524
  
 export default function Document() {
   return (

--- a/web/src/app/add/components/AddConstituentForm.module.css
+++ b/web/src/app/add/components/AddConstituentForm.module.css
@@ -1,0 +1,10 @@
+.form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 80%;
+    max-width: 500px;
+    margin: 40px;
+    gap: 20px;
+}

--- a/web/src/app/add/components/AddConstituentForm.module.css
+++ b/web/src/app/add/components/AddConstituentForm.module.css
@@ -1,10 +1,19 @@
+.inputs {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    align-items: center;
+    height: 80%;
+    max-width: 500px;
+    margin: 40px;
+    gap: 20px;
+    z-index: 500;
+}
+
 .form {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    height: 80%;
-    max-width: 500px;
-    margin: 40px;
-    gap: 20px;
-}
+    padding: 20px;
+    margin: 20px;
+} 

--- a/web/src/app/add/components/AddConstituentForm.tsx
+++ b/web/src/app/add/components/AddConstituentForm.tsx
@@ -121,7 +121,6 @@ export const AddConstituentForm = () => {
         onChange={handleInputChange}
         select
         value={party}
-        style={{width: '100%'}}
       >
         {Object.values(Party).map((party) => (
           <MenuItem key={party} value={party}>

--- a/web/src/app/add/components/AddConstituentForm.tsx
+++ b/web/src/app/add/components/AddConstituentForm.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { TextField, Button, MenuItem } from "@mui/material";
+import { useState } from "react";
+import { Party } from "@/typeDefs/typeDef";
+import styles from './AddConstituentForm.module.css';
+
+export const AddConstituentForm = () => {
+  const [name, setName] = useState<string>('');
+  const [email, setEmail] = useState<string>('');
+  const [phone, setPhone] = useState<string>('');
+  const [party, setParty] = useState<Party | ''>('');
+  const [city, setCity] = useState<string>('');
+  const [state, setState] = useState<string>('');
+
+  // would pull this from auth login/app state info in a real app
+  const representativeId = 3;
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    switch (e.target.name) {
+      case 'name':
+        setName(e.target.value);
+        break;
+      case 'email':
+        setEmail(e.target.value);
+        break;
+      case 'phone':
+        setPhone(e.target.value);
+        break;
+      case 'party':
+        setParty(e.target.value as Party);
+        break;
+      case 'city':
+        setCity(e.target.value);
+        break;
+      case 'state':
+        setState(e.target.value);
+        break;
+    }
+  }
+
+  const handleSubmit = () => {
+    const constituent = {
+      name,
+      email,
+      phone,
+      party,
+      city,
+      state,
+      representative_id: representativeId,
+    }
+
+    const requestBody = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(constituent)
+    }
+
+    fetch('http://localhost:4000/constituent', requestBody)
+      .then(res => res.json())
+      .then((data) => {
+        console.log('Constituent added', data);
+        window.location.href = "/";
+      })
+      .catch((e) => {
+        console.error(e);
+      })
+  }
+
+  return (
+    <div className={styles.form}>
+      <TextField 
+        placeholder="John Doe" 
+        label="Name"
+        name="name"
+        required
+        onChange={handleInputChange}
+        variant='outlined'
+        value={name}
+      />
+      <TextField 
+        placeholder="john.doe@mail.com" 
+        label="Email"
+        name="email"
+        required
+        onChange={handleInputChange}
+        value={email}
+      />
+      <TextField 
+        placeholder="###-##-####" 
+        label="Phone number"
+        name="phone"
+        required
+        onChange={handleInputChange}
+        value={phone}
+      />
+      <TextField 
+        placeholder="Political Party" 
+        label="Political Party"
+        name="party"
+        required
+        onChange={handleInputChange}
+        select
+        value={party}
+        style={{width: '100%'}}
+      >
+        {Object.values(Party).map((party) => (
+          <MenuItem key={party} value={party}>
+            {party}
+          </MenuItem>
+        ))}
+      </TextField>
+      <TextField 
+        placeholder="Denver" 
+        label="City"
+        name="city"
+        required
+        onChange={handleInputChange}
+        value={city}
+      />
+      <TextField 
+        placeholder="CO" 
+        label="State"
+        name="state"
+        required
+        onChange={handleInputChange}
+        value={state}
+      />
+      <Button variant='contained' onClick={handleSubmit} disabled={ !name || !email || !phone || !party || !city || !state}>Add Constituent</Button>
+    </div>
+  )
+}

--- a/web/src/app/add/components/AddConstituentForm.tsx
+++ b/web/src/app/add/components/AddConstituentForm.tsx
@@ -86,7 +86,9 @@ export const AddConstituentForm = () => {
 
   return (
     <div className={styles.form}>
+    <div className={styles.inputs}>
       <TextField 
+        className={styles.input}
         placeholder="John Doe" 
         label="Name"
         name="name"
@@ -143,6 +145,7 @@ export const AddConstituentForm = () => {
         onChange={handleInputChange}
         value={state}
       />
+      </div>
       <Button variant='contained' onClick={handleSubmit} disabled={ !name || !email || !phone || !party || !city || !state}>Add Constituent</Button>
       <Snackbar
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}

--- a/web/src/app/add/components/AddConstituentForm.tsx
+++ b/web/src/app/add/components/AddConstituentForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { TextField, Button, MenuItem } from "@mui/material";
+import { TextField, Button, MenuItem, Snackbar } from "@mui/material";
 import { useState } from "react";
 import { Constituent, Party } from "@/typeDefs/typeDef";
 import styles from './AddConstituentForm.module.css';
@@ -12,6 +12,8 @@ export const AddConstituentForm = () => {
   const [party, setParty] = useState<Party>('' as Party);
   const [city, setCity] = useState<string>('');
   const [state, setState] = useState<string>('');
+  const [showSnackbar, setShowSnackbar] = useState<boolean>(false);
+  const [snackbarMessage, setSnackbarMessage] = useState<string>('');
 
   // would pull this from auth login/app state info in a real app
   const representativeId = 3;
@@ -37,7 +39,16 @@ export const AddConstituentForm = () => {
         setState(e.target.value);
         break;
     }
-  }
+  };
+
+  const clearInputs = () => {
+    setName('');
+    setEmail('');
+    setPhone('');
+    setParty('' as Party);
+    setCity('');
+    setState('');
+  };
 
   const handleSubmit = () => {
 
@@ -62,11 +73,14 @@ export const AddConstituentForm = () => {
     fetch('http://localhost:4000/addConstituent', requestBody)
       .then(res => res.json())
       .then((data) => {
-        console.log('Constituent added', data);
-        window.location.href = "/";
+        setShowSnackbar(true);
+        setSnackbarMessage(data.error === 'Constituent already exists' ? 'Constituent already exists' : `Constituent ${data.name} added successfully`);
+        clearInputs();
       })
       .catch((e) => {
         console.error(e);
+        setShowSnackbar(true);
+        setSnackbarMessage('Error adding constituent');
       })
   }
 
@@ -130,6 +144,13 @@ export const AddConstituentForm = () => {
         value={state}
       />
       <Button variant='contained' onClick={handleSubmit} disabled={ !name || !email || !phone || !party || !city || !state}>Add Constituent</Button>
+      <Snackbar
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        open={showSnackbar}
+        onClose={() => setShowSnackbar(false)}
+        message={snackbarMessage}
+        autoHideDuration={3000}
+      />
     </div>
   )
 }

--- a/web/src/app/add/components/AddConstituentForm.tsx
+++ b/web/src/app/add/components/AddConstituentForm.tsx
@@ -2,14 +2,14 @@
 
 import { TextField, Button, MenuItem } from "@mui/material";
 import { useState } from "react";
-import { Party } from "@/typeDefs/typeDef";
+import { Constituent, Party } from "@/typeDefs/typeDef";
 import styles from './AddConstituentForm.module.css';
 
 export const AddConstituentForm = () => {
   const [name, setName] = useState<string>('');
   const [email, setEmail] = useState<string>('');
   const [phone, setPhone] = useState<string>('');
-  const [party, setParty] = useState<Party | ''>('');
+  const [party, setParty] = useState<Party>('' as Party);
   const [city, setCity] = useState<string>('');
   const [state, setState] = useState<string>('');
 
@@ -40,7 +40,8 @@ export const AddConstituentForm = () => {
   }
 
   const handleSubmit = () => {
-    const constituent = {
+
+    const constituent : Constituent = {
       name,
       email,
       phone,
@@ -58,7 +59,7 @@ export const AddConstituentForm = () => {
       body: JSON.stringify(constituent)
     }
 
-    fetch('http://localhost:4000/constituent', requestBody)
+    fetch('http://localhost:4000/addConstituent', requestBody)
       .then(res => res.json())
       .then((data) => {
         console.log('Constituent added', data);

--- a/web/src/app/add/page.module.css
+++ b/web/src/app/add/page.module.css
@@ -1,0 +1,8 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-items: center;
+  min-height: 100svh;
+  padding: 10px 0;
+}

--- a/web/src/app/add/page.tsx
+++ b/web/src/app/add/page.tsx
@@ -1,11 +1,12 @@
-import { Button } from "@mui/material";
+import { AddConstituentForm } from "./components/AddConstituentForm";
+import styles from './page.module.css';
 
 const AddConstituentPage = () => {
 
   return (
-    <div>
+    <div className={styles.page}>
       <h1>Add a constituent here!</h1>
-      <Button variant="contained" color="primary">Add Constituent</Button>
+      <AddConstituentForm />
     </div>
   )
 }

--- a/web/src/app/components/ConstituentTable.tsx
+++ b/web/src/app/components/ConstituentTable.tsx
@@ -60,6 +60,8 @@ export const ConstituentTable = ({ constituents }: { constituents: Constituent[]
         onPageChange={handlePageChange}
         rowsPerPage={rowsPerPage}
         onRowsPerPageChange={handleRowsPerPageChange}
+        showFirstButton
+        showLastButton
       />
     </div>
   )

--- a/web/src/app/components/ConstituentTable.tsx
+++ b/web/src/app/components/ConstituentTable.tsx
@@ -3,6 +3,10 @@ import { Table, TableBody, TableCell, TableHead, TableRow, TablePagination } fro
 import { Constituent } from '../../typeDefs/typeDef';
 import styled from '@emotion/styled';
 
+// Table pagination select component throws warning about using the native select element
+// This is a known issue with MUI
+// https://stackoverflow.com/questions/76491601/accessibility-issues-coming-in-mui-components
+
 const StyledTable = styled(Table)`
   width: 1000px;
 `

--- a/web/src/app/components/ConstituentTable.tsx
+++ b/web/src/app/components/ConstituentTable.tsx
@@ -18,7 +18,7 @@ export const ConstituentTable = ({ constituents }: { constituents: Constituent[]
         <TableCell>{constituent.name}</TableCell>
         <TableCell>{constituent.email}</TableCell>
         <TableCell>{constituent.phone}</TableCell>
-        <TableCell>{new Date(constituent.date_joined).toLocaleDateString()}</TableCell>
+        <TableCell>{constituent.date_joined ? new Date(constituent.date_joined).toLocaleDateString() : ''}</TableCell>
         <TableCell>{constituent.party}</TableCell>
         <TableCell>{constituent.city}</TableCell>
         <TableCell>{constituent.state}</TableCell>

--- a/web/src/app/components/NavBar.module.css
+++ b/web/src/app/components/NavBar.module.css
@@ -1,0 +1,28 @@
+.nav {
+  width: 100%;
+  height: 50px;
+  background-color: #330072;
+  color: #f5b27e;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 20px;
+  padding: 15px;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+.link {
+  color: #f5b27e;
+  text-decoration: none;
+  height: 40px;
+  border-radius: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 10px;
+}
+
+.link:hover {
+  background-color: rgba(245, 178, 126, 0.3);
+}

--- a/web/src/app/components/NavBar.tsx
+++ b/web/src/app/components/NavBar.tsx
@@ -1,45 +1,17 @@
 'use client'
 
 import Link from 'next/link';
-import styled from '@emotion/styled';
-
-const StyledNav = styled.nav`
-  width: 100%;
-  height: 50px;
-  background-color: #330072;
-  color: #f5b27e;
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 20px;
-  padding: 15px;
-  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.25);
-`
-
-const StyledLink = styled(Link)`
-  color: #f5b27e;
-  text-decoration: none;
-  height: 40px;
-  border-radius: 5px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 0 10px;
-  :hover {
-    background-color: rgba(245, 178, 126, 0.3);
-  }
-`
+import styles from './NavBar.module.css';
 
 export const NavBar = () => {
   return (
-    <StyledNav>
-      <StyledLink href="/">
-        Home
-      </StyledLink>
-      <StyledLink href="/add">
+    <nav className={styles.nav}>
+      <Link href="/" className={styles.link}>
+        View Constituents
+      </Link>
+      <Link href="/add" className={styles.link}>
         Add Constituent
-      </StyledLink>
-    </StyledNav>
+      </Link>
+    </nav>
   )
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,24 +1,9 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import '@fontsource/roboto/300.css';
-import '@fontsource/roboto/400.css';
-import '@fontsource/roboto/500.css';
-import '@fontsource/roboto/700.css';
 import { ThemeProvider } from "@mui/material";
 import { theme } from '../theme/theme';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { NavBar } from "./components/NavBar";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Representative Portal",
@@ -32,7 +17,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+      <body>
       <AppRouterCacheProvider>
         <ThemeProvider theme={theme}>
           <NavBar />

--- a/web/src/app/page.module.css
+++ b/web/src/app/page.module.css
@@ -4,7 +4,6 @@
   align-items: center;
   justify-items: center;
   min-height: 100svh;
-  font-family: var(--font-geist-sans);
   padding: 10px 0;
 }
 

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -28,7 +28,7 @@ export default function Home() {
 
   useEffect(() => {
     // fetch the constituents from the backend
-    fetch(`http://localhost:4000/constituents?id=${representativeId}`)
+    fetch(`http://localhost:4000/constituents?representativeId=${representativeId}`)
       .then(res => res.json())
       .then((data) => {
         setConstituents(data);

--- a/web/src/typeDefs/typeDef.ts
+++ b/web/src/typeDefs/typeDef.ts
@@ -35,7 +35,7 @@ export type Constituent = {
   name: string;
   email: string;
   phone: string;
-  id: number;
+  id?: number;
   date_joined: string;
   party: Party;
   state: string;

--- a/web/src/typeDefs/typeDef.ts
+++ b/web/src/typeDefs/typeDef.ts
@@ -36,7 +36,7 @@ export type Constituent = {
   email: string;
   phone: string;
   id?: number;
-  date_joined: string;
+  date_joined?: string;
   party: Party;
   state: string;
   city: string;


### PR DESCRIPTION
This PR adds functionality for the representative to add constituents to their data 

Endpoint with error handling on the back end to injest the constituent object sent from the front end. If they already exist, the constituent is returned to the front end with an error message to alert the representative. If the constituent doesn't exist, they're added to the dataset. 

On the front end a form was added to allow for the representative to enter their constituent information, and add it to the dataset. Snackbars were added as feedback in the event of successful addition, already existing constituent, and an error returned from the back end. 


<img width="1111" alt="Screenshot 2025-01-16 at 7 16 50 PM" src="https://github.com/user-attachments/assets/f2479f21-6f2a-48f0-9b22-deec4cf9d0d3" />

There's a few errors/warnings that persist in the console, but aren't worth wasting any more time on. They shouldn't affect the app or user experience.


![Screenshot 2025-01-16 at 7 25 02 PM](https://github.com/user-attachments/assets/9590969d-4c01-4569-bb65-5517ee1433a6)

https://github.com/vercel/next.js/issues/51524


![Screenshot 2025-01-16 at 7 25 34 PM](https://github.com/user-attachments/assets/852f7d43-20b3-447b-b28a-2cb45ec730b2)

https://stackoverflow.com/questions/76491601/accessibility-issues-coming-in-mui-components


